### PR TITLE
V0.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Dbus
+        shell: bash
+        run: |
+          sudo apt install -y libdbus-1-dev
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -55,6 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Dbus
+        shell: bash
+        run: |
+          sudo apt install -y libdbus-1-dev
 
       - uses: actions/cache@v2
         with:
@@ -96,6 +106,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Dbus
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt install -y libdbus-1-dev
 
       - uses: actions/cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+
+[[package]]
+name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -125,6 +131,12 @@ dependencies = [
  "arrayvec",
  "constant_time_eq",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -213,7 +225,7 @@ checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -226,7 +238,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -358,6 +370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd9e78c210146a1860f897db03412fd5091fd73100778e43ee255cca252cf32"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +405,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 dependencies = [
  "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -443,8 +476,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "synstructure",
 ]
 
@@ -498,6 +531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,7 +552,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "fuchsia-zircon-sys",
 ]
 
@@ -882,6 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc12a3bc971424edbbf7edaf6e5740483444db63aa8e23d3751ff12a30f306f0"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +955,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb6b71a9a89cd38b395d994214297447e8e63b1ba5708a9a2b0b1048ceda76"
+dependencies = [
+ "cc",
+ "chrono",
+ "dirs",
+ "objc-foundation",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -934,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "mendo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +1015,9 @@ dependencies = [
  "confy",
  "directories 3.0.1",
  "fern",
+ "fs2",
  "log",
+ "notify-rust",
  "oauth2",
  "open",
  "regex",
@@ -951,6 +1026,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "url 2.1.1",
+ "xkcd_unreachable",
  "yaml-rust",
 ]
 
@@ -1040,6 +1116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144acee6a0543dc74893e4b8a33936b5b0a94cc2d4ab024afd0c6daff7afc3c0"
+dependencies = [
+ "dbus",
+ "mac-notification-sys",
+ "winrt-notification",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1175,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
 name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,7 +1236,7 @@ version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if",
  "foreign-types",
  "lazy_static",
@@ -1201,8 +1317,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1235,7 +1351,7 @@ version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1250,6 +1366,12 @@ dependencies = [
  "regex",
  "url 2.1.1",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -1585,7 +1707,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1633,8 +1755,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1739,14 +1861,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strum"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca6e4730f517e041e547ffe23d29daab8de6b73af4b6ae2a002108169f5e7da"
+
+[[package]]
+name = "strum_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3384590878eb0cab3b128e844412e2d010821e7e091211b9d87324173ada7db8"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2",
- "quote",
- "unicode-xid",
+ "quote 1.0.7",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -1756,9 +1914,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "quote 1.0.7",
+ "syn 1.0.38",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -2060,6 +2218,12 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
@@ -2162,8 +2326,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -2185,7 +2349,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
- "quote",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2196,8 +2360,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2271,6 +2435,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winrt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30cba82e22b083dc5a422c2ee77e20dc7927271a0dc981360c57c1453cb48d"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winrt-notification"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c31a65da50d792c6f9bd2e3216249566c4fb1d2d34f9b7d2d66d2e93f62a242"
+dependencies = [
+ "strum",
+ "strum_macros",
+ "winapi 0.3.9",
+ "winrt",
+ "xml-rs",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2464,21 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xkcd_unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0fd7a53be8f9d15f424de10c67a1ab4dfc09c957d0d1cf295eb1e87d6a6c6d"
+
+[[package]]
+name = "xml-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1945e12e16b951721d7976520b0832496ef79c31602c7a29d950de79ba74621"
+dependencies = [
+ "bitflags 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendo"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Rudo2204 <rudo2204@gmail.com>"]
 edition = "2018"
 description = "A CLI program to update manga progress"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ chrono = "0.4"
 yaml-rust = "0.4.4"
 serde_yaml = "0.8.13"
 xkcd_unreachable = "0.1.1"
+fs2 = "0.4.3"
+
 [target.'cfg(unix)'.dependencies]
 notify-rust = "4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ chrono = "0.4"
 yaml-rust = "0.4.4"
 serde_yaml = "0.8.13"
 xkcd_unreachable = "0.1.1"
+[target.'cfg(unix)'.dependencies]
+notify-rust = "4"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = "2.33"
 chrono = "0.4"
 yaml-rust = "0.4.4"
 serde_yaml = "0.8.13"
+xkcd_unreachable = "0.1.1"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -39,20 +39,9 @@ SUBCOMMANDS:
 ```
 
 ## Authorization process
-You will need to authorize `mendo` to update your process.\
-First start `mendo auth`, it will create a new config yaml file in your configuration directory. Refer to the table below.
-
-| Platform | Value                                         | Example                                        |
-|----------|-----------------------------------------------|------------------------------------------------|
-| Linux    | $XDG_CONFIG_HOME/mendo or $HOME/.config/mendo | /home/alice/.config/mendo                      |
-| OSX      | $HOME/Library/Application Support/mendo       | /Users/Alice/Library/Application Support/mendo |
-| Windows  | {FOLDERID_RoamingAppData}\mendo\config        | C:\Users\Alice\AppData\Roaming\mendo\config    |
-
-Then come to [API Clients page of Anilist](https://anilist.co/settings/developer) and create a new client.
-In the `Name` field, put whatever you want, in the `Redirect URL` field, put `http://localhost:8080/callback` and then click `Save`. It will proceed to create a new client.
-Then open the config file in your configuration directory in the above step, edit it with the information given from Anilist. (Edit the name, id, secret fields, leave the token field)
-
-Then the final step is to start `mendo` up again to kick start your authorization process. When the authorization process finishes, it will save an access token to your config file and you are ready to go.
+You need to authorize `mendo` to use the main feature of the program which is the `update` feature.
+To start the authorization process, simply type `mendo auth` in your terminal. It will open your browser and redirect you to Anilist page where you would press another green button Authorize to complete the process. That's it.\
+**Note:** If you somehow mess up something and need to reauthorize, you can use `mendo auth --force` to force `mendo` to reauthorize you.
 
 ## How to integrate with MComix
 Open MComix, File -> Open with -> Edit commands. Add a new external command, call it whatever you want.\

--- a/README.md
+++ b/README.md
@@ -21,25 +21,26 @@ So there are two solutions to this:
 
 ## Mendo help page
 ```
-mendo 0.1.0
+mendo 0.2.0
 Rudo2204 <rudo2204@gmail.com>
 A CLI program to update manga progress
 
 USAGE:
-    mendo [FLAGS] <filename>
+    mendo [FLAGS] [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
     -v, --verbose    Sets the level of debug information verbosity
 
-ARGS:
-    <filename>    the filename of manga archive
+SUBCOMMANDS:
+    auth      Authorizes mendo to update progress
+    update    Updates manga progress
 ```
 
 ## Authorization process
 You will need to authorize `mendo` to update your process.\
-First, start `mendo` up (just put in some random filename as args), it will create a new config yaml file in your configuration directory. Refer to the table below.
+First start `mendo auth`, it will create a new config yaml file in your configuration directory. Refer to the table below.
 
 | Platform | Value                                         | Example                                        |
 |----------|-----------------------------------------------|------------------------------------------------|
@@ -55,7 +56,7 @@ Then the final step is to start `mendo` up again to kick start your authorizatio
 
 ## How to integrate with MComix
 Open MComix, File -> Open with -> Edit commands. Add a new external command, call it whatever you want.\
-And the command would be `/path/to/mendo %a`. You can add a some `-v` to increase debug information logged to your data directory. You should find a directory named `mendo` in there. Refer to the table below.
+And the command would be `/path/to/mendo update %a`. You can add a some `-v` to increase debug information logged to your data directory. You should find a directory named `mendo` in there. Refer to the table below.
 
 | Platform | Value                                            | Example                                        |
 |----------|--------------------------------------------------|------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ And the command would be `/path/to/mendo update %a`. You can add a some `-v` to 
 
 ## How to actually use it
 So when you are done with the integration process, open your manga archives and read them like normal. When you come to a new chapter, press the assigned external button corresponding to `mendo` command. It will automatically update +1 to your manga progress. Yay.\
-**NOTE:** The filename of your manga archive MUST match the regex `^(.*) v?(\d+)` (all manga rippers use this naming convention I think?) else it won't work. The actual manga name can be in their native name, romaji or english. As long as it's the first result when you search on Anilist it should work.
+**NOTE:** By default, the regex pattern `^(.*) (v?|c?)\d+` (most manga rippers use this naming convention) is used to get the manga title from the archived file. You can override this pattern with the optional flag `--regexp` (or `-e` for short). The manga title can be in their native name, romaji or english. As long as it's the first result when you search on Anilist it should work.
 
 ## Contribute
 [Create new issue](https://github.com/Rudo2204/rtend/issues) if you meet any bugs or have any ideas.\

--- a/src/anilist/request.rs
+++ b/src/anilist/request.rs
@@ -3,13 +3,14 @@ use log::{debug, error, info, warn};
 use reqwest::{blocking::Client, StatusCode};
 use serde::de::DeserializeOwned;
 use serde_json::{json, Map, Value};
-use std::{thread, time};
+use std::{fs::remove_file, thread, time};
 
 use super::model::{
     MediaListResponse, MediaListStatus, MediaResponse, MediaStatus, MediaType, QueryResponse,
     SaveMediaListEntry, ViewerResponse,
 };
 use super::query::{QUERY_MEDIA_LIST, QUERY_USER, SEARCH_MEDIA, UPDATE_MEDIA};
+use crate::util;
 use crate::util::MendoConfig;
 use crate::PROGRAM_NAME;
 
@@ -70,6 +71,8 @@ where
                 let response: QueryResponse<R> = res.json()?;
                 debug!("Response =\n{:#?}", response);
                 debug!("Deleting the existing token to force user to reauth...");
+                let user_profile_path = util::get_data_dir("", "", PROGRAM_NAME)?.join("user.yml");
+                remove_file(&user_profile_path)?;
                 confy::store(
                     PROGRAM_NAME,
                     MendoConfig {

--- a/src/anilist/request.rs
+++ b/src/anilist/request.rs
@@ -73,16 +73,7 @@ where
                 debug!("Deleting the existing token to force user to reauth...");
                 let user_profile_path = util::get_data_dir("", "", PROGRAM_NAME)?.join("user.yml");
                 remove_file(&user_profile_path)?;
-                confy::store(
-                    PROGRAM_NAME,
-                    MendoConfig {
-                        id: cfg.id,
-                        secret: cfg.secret.to_string(),
-                        name: cfg.name.to_string(),
-                        url: cfg.url.to_string(),
-                        token: "Leave this field.".to_string(),
-                    },
-                )?;
+                confy::store(PROGRAM_NAME, MendoConfig::default())?;
                 return Err(anyhow!("Unthorized! Run the program again to reauthorize!"));
             }
             // This could happen in two situations:

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,12 +118,11 @@ fn main() -> Result<()> {
 
     util::create_data_dir(&data_dir)?;
     setup_logging(verbosity)?;
-    debug!("-----Logger is initialized. Starting main program!-----");
-
     let log_file_path =
         util::get_data_dir("", "", PROGRAM_NAME)?.join(format!("{}.log", PROGRAM_NAME));
     let log_file = File::open(log_file_path)?;
     log_file.lock_exclusive()?;
+    debug!("-----Logger is initialized. Starting main program!-----");
 
     let conf_file = util::get_conf_dir("", "", PROGRAM_NAME)?;
     while !conf_file.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{crate_authors, crate_description, crate_version, App, AppSettings, Arg};
 use fs2::FileExt;
 use reqwest::blocking::Client;
@@ -6,7 +6,7 @@ use std::{fs::File, io};
 
 use chrono::{Local, Utc};
 use fern::colors::{Color, ColoredLevelConfig};
-use log::{debug, error, info, LevelFilter};
+use log::{debug, info, LevelFilter};
 
 mod anilist;
 mod util;
@@ -152,16 +152,7 @@ fn main() -> Result<()> {
     let mut mendo_cfg: MendoConfig = confy::load(PROGRAM_NAME)?;
     if let Some(auth_matches) = matches.subcommand_matches("auth") {
         debug!("Config file loaded. Checking for auth status...");
-        if !mendo_cfg.ready_to_auth() {
-            println!(
-            "You need to edit information in the config file first before we can authorize you."
-            );
-            println!("Mendo's config file is located at {}", conf_file.display());
-            error!("One or more fields in conf file has not been edited. Exiting...");
-            return Err(anyhow!(
-                "One or more fields in conf file has not been edited!"
-            ));
-        } else if !mendo_cfg.access_token_is_valid() || auth_matches.is_present("force") {
+        if !mendo_cfg.access_token_is_valid() || auth_matches.is_present("force") {
             info!("Starting authorization process...");
             println!("Starting authorization process...");
             let res_token = oauth::auth(&mut mendo_cfg)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,9 @@ fn main() -> Result<()> {
         let (entry_id, progress) = util::get_eid_and_progress(&mut mendo_cfg, user_id, media_id)?;
 
         request::update_media(&mut mendo_cfg, entry_id, progress + 1)?;
+
+        #[cfg(target_family = "unix")]
+        util::notify_updated(&filename, progress + 1)?;
     }
 
     debug!("-----Everything is finished!-----");

--- a/src/util.rs
+++ b/src/util.rs
@@ -147,6 +147,7 @@ pub fn notify_updated(filename: &str, pattern: &str, progress: i32) -> Result<No
     let name = get_manga_name(&filename, &pattern)?;
     Ok(Notification::new()
         .appname("mendo")
+        .timeout(2000)
         .summary(format!("Updated manga `{}` with progress `{}`", name, progress).as_str())
         .show()?)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,9 +35,9 @@ pub struct MendoConfig {
 impl Default for MendoConfig {
     fn default() -> Self {
         MendoConfig {
-            id: 0,
-            secret: "Edit this!".to_string(),
-            name: "Edit this!".to_string(),
+            id: 3891,
+            secret: "ASEXk9zRXXkpbXSrzxNn89fuGDyiVmS3qkszaUXb".to_string(),
+            name: "mendo".to_string(),
             url: "http://localhost:8080/callback".to_string(),
             token: "Leave this field.".to_string(),
         }
@@ -47,10 +47,6 @@ impl Default for MendoConfig {
 impl MendoConfig {
     pub fn access_token_is_valid(&mut self) -> bool {
         self.token != "Leave this field."
-    }
-
-    pub fn ready_to_auth(&mut self) -> bool {
-        !(self.id == 0 || self.secret == "Edit this!" || self.name == "Edit this!")
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -178,11 +178,7 @@ pub fn get_media_id(mut cfg: &mut MendoConfig, data_dir: &PathBuf, filename: &st
                     append_local_data(&local_media_data, name, media_id)?;
                     Ok(media_id)
                 }
-                None => {
-                    // the program should never reach this state!
-                    error!("Could not get ids from querying API!");
-                    Err(anyhow!("Could not get ids from querying API!"))
-                }
+                None => xkcd_unreachable::xkcd_unreachable!(),
             }
         }
     }
@@ -210,10 +206,6 @@ pub fn get_eid_and_progress(
             media_list_resp.media_list.entry_id,
             media_list_resp.media_list.progress,
         )),
-        None => {
-            // the program should never reach this state!
-            error!("Could not get progress from querying API!");
-            Err(anyhow!("Could not get progress from querying API!"))
-        }
+        None => xkcd_unreachable::xkcd_unreachable!(),
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 use directories::ProjectDirs;
 use log::{debug, error, info};
-use notify_rust::{Notification, NotificationHandle};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
@@ -10,6 +9,9 @@ use std::path::PathBuf;
 
 use crate::anilist::model::{MediaType, User};
 use crate::anilist::request;
+
+#[cfg(target_family = "unix")]
+use notify_rust::{Notification, NotificationHandle};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct AnilistToken<'a> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -148,7 +148,7 @@ pub fn notify_updated(filename: &str, progress: i32) -> Result<NotificationHandl
     let name = get_manga_name(&filename)?;
     Ok(Notification::new()
         .appname("mendo")
-        .summary(format!("Updated manga `{}` with progress `{}`", name, progress + 1).as_str())
+        .summary(format!("Updated manga `{}` with progress `{}`", name, progress).as_str())
         .show()?)
 }
 


### PR DESCRIPTION
Changes:
* [BREAKING] Break the program into two subcommands: `auth` and `update`.
* Hardcoded my personal client id and secret to the program.
* Now can use `--regexp` (or `-e` for short) to override regexp used to get manga name from archive.
* Various misc improvements like properly reuse client, better error handling
* Misc: Now use `xkcd_unreachable` macro to handle unreachable code.
New features:
* [UNIX ONLY FOR NOW] Notify the user with updated progress when the update process finishes.
* Add locking mechanism to avoid updating the same progress multiple times.

Close #5, close #6, close #7 